### PR TITLE
User profile image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Xcode
+
+## Various settings
+xcuserdata/

--- a/Learn.xcodeproj/project.pbxproj
+++ b/Learn.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		098518DCFB48A0770163C409 /* Pods_Learn.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2ED797032375B2335F2567A3 /* Pods_Learn.framework */; };
+		6709867E22545ECC009E0BAE /* Batch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6709867D22545ECC009E0BAE /* Batch.swift */; };
+		6709868022545EE3009E0BAE /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6709867F22545EE3009E0BAE /* Track.swift */; };
+		6709868222545EF6009E0BAE /* Course.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6709868122545EF6009E0BAE /* Course.swift */; };
 		8F40F1DC20FBB1FB0090C604 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F40F1DB20FBB1FB0090C604 /* AppDelegate.swift */; };
 		8F40F1DE20FBB1FB0090C604 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F40F1DD20FBB1FB0090C604 /* HomeViewController.swift */; };
 		8F40F1E120FBB1FB0090C604 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8F40F1DF20FBB1FB0090C604 /* Main.storyboard */; };
@@ -26,6 +29,9 @@
 /* Begin PBXFileReference section */
 		2ED797032375B2335F2567A3 /* Pods_Learn.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Learn.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5957DFBC70FC2B76E9197AD8 /* Pods-Learn.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Learn.release.xcconfig"; path = "Pods/Target Support Files/Pods-Learn/Pods-Learn.release.xcconfig"; sourceTree = "<group>"; };
+		6709867D22545ECC009E0BAE /* Batch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Batch.swift; sourceTree = "<group>"; };
+		6709867F22545EE3009E0BAE /* Track.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Track.swift; sourceTree = "<group>"; };
+		6709868122545EF6009E0BAE /* Course.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Course.swift; sourceTree = "<group>"; };
 		8F40F1D820FBB1FB0090C604 /* Learn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Learn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F40F1DB20FBB1FB0090C604 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8F40F1DD20FBB1FB0090C604 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
@@ -104,6 +110,9 @@
 			isa = PBXGroup;
 			children = (
 				C10C56C621026B3100D903E8 /* User.swift */,
+				6709867D22545ECC009E0BAE /* Batch.swift */,
+				6709867F22545EE3009E0BAE /* Track.swift */,
+				6709868122545EF6009E0BAE /* Course.swift */,
 			);
 			path = models;
 			sourceTree = "<group>";
@@ -284,16 +293,19 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6709868222545EF6009E0BAE /* Course.swift in Sources */,
 				C10C56CD21026D8100D903E8 /* UserDataStore.swift in Sources */,
 				C10C56D92102832A00D903E8 /* LessonsViewController.swift in Sources */,
 				C10C56CA21026CC100D903E8 /* Switcher.swift in Sources */,
 				C10C56C721026B3100D903E8 /* User.swift in Sources */,
 				C18235C320FFB71700244E27 /* LearnApi.swift in Sources */,
+				6709867E22545ECC009E0BAE /* Batch.swift in Sources */,
 				C10C56D121027A3A00D903E8 /* LoginViewController.swift in Sources */,
 				C10C56CF21026E6700D903E8 /* Constants.swift in Sources */,
 				8F40F1DE20FBB1FB0090C604 /* HomeViewController.swift in Sources */,
 				C10C56D5210282CE00D903E8 /* LessonViewController.swift in Sources */,
 				8F40F1DC20FBB1FB0090C604 /* AppDelegate.swift in Sources */,
+				6709868022545EE3009E0BAE /* Track.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Learn/adapters/LearnApi.swift
+++ b/Learn/adapters/LearnApi.swift
@@ -9,6 +9,25 @@
 import Alamofire
 
 struct LearnApi {
+    static func getProfile(completion: @escaping (Student) -> ()) {
+        let headers: HTTPHeaders = [
+            "Authorization": "Bearer be6fd5e3d25ef654e1dcc630d1f2f6e7bcbea59e5a3c0899b447bc631c90cad2",
+            "Content-Type": "application/json",
+            "Accept": "version=1"
+        ]
+        
+        Alamofire.request("\(Constants.localLearnAPI)/api/profiles/me", headers: headers).responseData { (res) in
+            if let data = res.data {
+                let decoder = JSONDecoder()
+                decoder.keyDecodingStrategy = .convertFromSnakeCase
+                
+                let student = try! decoder.decode(Student.self, from: data)
+                
+                completion(student)
+            }
+        }
+    }
+    
     static func getCanonicalProgress(batch: String , track: String, completion: @escaping (Student) -> ()) {
     
         let headers: HTTPHeaders = [

--- a/Learn/adapters/LearnApi.swift
+++ b/Learn/adapters/LearnApi.swift
@@ -15,10 +15,9 @@ struct LearnApi {
             "Authorization": "Bearer 27c136770c55d8e66f4aff9fdb4e879abdab6385b4ce035ca004906baf74f1fb",
             "Content-Type": "application/json",
             "Accept": "version=1"
-            
         ]
         
-        Alamofire.request("https://learn.co/api/batches/\(batch)/tracks/\(track)", headers: headers).responseData { (res) in
+        Alamofire.request("\(Constants.learnAPI)/api/batches/\(batch)/tracks/\(track)", headers: headers).responseData { (res) in
             
             if let data = res.data {
                 let decoder = JSONDecoder()
@@ -30,8 +29,6 @@ struct LearnApi {
                 }).first {
                     completion(student)
                 }
-                
-
             }
             
         }

--- a/Learn/controllers/Auth/LoginViewController.swift
+++ b/Learn/controllers/Auth/LoginViewController.swift
@@ -24,25 +24,27 @@ class LoginViewController: UIViewController {
     }
     
     @IBAction func loginPressed(_ sender: Any) {
-        let oauthswift = OAuth2Swift(consumerKey: "c00d880168abfa5409b69c9267989a60019d5757fcf5095c1bdc16513f48dd49", consumerSecret: "726ed128be992068be3ea6579d5ef49c47eb78dc82366ff20dc1fc89c472bef2", authorizeUrl: "https://learn.co/oauth/authorize", accessTokenUrl: "https://learn.co/oauth/token", responseType: "code")
-        
-        oauthswift.allowMissingStateCheck = true
-        //2
-        oauthswift.authorizeURLHandler = SafariURLHandler(viewController: self, oauthSwift: oauthswift)
-        
-        let _ = oauthswift.authorize(
-            withCallbackURL: URL(string: "learn-auth://learn/callback")!,
-            scope: "", state: "",
-            success: { credential, response, parameters in
-                print(credential.oauthToken)
-                UserDefaults.standard.set(credential.oauthToken, forKey: "token")
-                Switcher.updateVC()
-        },
-            failure: { error in
-                
-                print(error.localizedDescription)
-        }
-        )
+    UserDefaults.standard.set("be6fd5e3d25ef654e1dcc630d1f2f6e7bcbea59e5a3c0899b447bc631c90cad2", forKey: "token")
+        Switcher.updateVC()
+//        let oauthswift = OAuth2Swift(consumerKey: "c00d880168abfa5409b69c9267989a60019d5757fcf5095c1bdc16513f48dd49", consumerSecret: "726ed128be992068be3ea6579d5ef49c47eb78dc82366ff20dc1fc89c472bef2", authorizeUrl: "https://learn.co/oauth/authorize", accessTokenUrl: "https://learn.co/oauth/token", responseType: "code")
+//
+//        oauthswift.allowMissingStateCheck = true
+//        //2
+//        oauthswift.authorizeURLHandler = SafariURLHandler(viewController: self, oauthSwift: oauthswift)
+//
+//        let _ = oauthswift.authorize(
+//            withCallbackURL: URL(string: "learn-auth://learn/callback")!,
+//            scope: "", state: "",
+//            success: { credential, response, parameters in
+//                print(credential.oauthToken)
+//                UserDefaults.standard.set(credential.oauthToken, forKey: "token")
+//                Switcher.updateVC()
+//        },
+//            failure: { error in
+//
+//                print(error.localizedDescription)
+//        }
+//        )
     }
 
     

--- a/Learn/controllers/HomeViewController.swift
+++ b/Learn/controllers/HomeViewController.swift
@@ -24,10 +24,15 @@ class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        store.fetchProgress { (studentWithProgress) in
-            print(studentWithProgress)
-            self.updateViewWith(studentWithProgress)
-
+//        store.fetchProgress { (studentWithProgress) in
+//            print(studentWithProgress)
+//            self.updateViewWith(studentWithProgress)
+//
+//        }
+        
+        store.fetchProfile { (student) in
+            print(student)
+            self.updateViewWith(student)
         }
       
         // Do any additional setup after loading the view, typically from a nib.
@@ -35,14 +40,10 @@ class HomeViewController: UIViewController {
     
     func updateViewWith(_ student: Student) {
         DispatchQueue.main.async {
-            self.nameLabel.text = "johann"
+            self.nameLabel.text = student.displayName
             self.velocityLabel.text = "\(student.velocity)"
-            self.completionLabel.text = "\(student.completedLabsCount)/\(student.totalLabsCount)"
-//            if let profileUrl = student.githubGravatar, let url = URL(string: profileUrl) {
-//                self.profileImageView.kf.setImage(with: url)
-//            }
-            let profileUrl = "https://avatars.githubusercontent.com/u/20468684"
-            if let url = URL(string: profileUrl) {
+            self.completionLabel.text = "\(student.completedLessonsCount)/\(student.totalLessonsCount)"
+            if let gravatarURL = student.gravatarUrl, let url = URL(string: gravatarURL) {
                 self.profileImageView.kf.setImage(with: url)
             }
         }

--- a/Learn/controllers/HomeViewController.swift
+++ b/Learn/controllers/HomeViewController.swift
@@ -19,16 +19,7 @@ class HomeViewController: UIViewController {
     @IBOutlet weak var velocityLabel: UILabel!
     @IBOutlet weak var nameLabel: UILabel!
     
-    
-    
-    
-    
-    
-    
-    
-    
     let store = UserDataStore.shared
-
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -57,6 +48,5 @@ class HomeViewController: UIViewController {
         }
     }
     
-
 }
 

--- a/Learn/controllers/HomeViewController.swift
+++ b/Learn/controllers/HomeViewController.swift
@@ -27,7 +27,7 @@ class HomeViewController: UIViewController {
         store.fetchProgress { (studentWithProgress) in
             print(studentWithProgress)
             self.updateViewWith(studentWithProgress)
-            
+
         }
       
         // Do any additional setup after loading the view, typically from a nib.

--- a/Learn/models/Batch.swift
+++ b/Learn/models/Batch.swift
@@ -1,0 +1,16 @@
+//
+//  Batch.swift
+//  Learn
+//
+//  Created by Luke Ghenco on 4/2/19.
+//  Copyright © 2019 Johann Kerr. All rights reserved.
+//
+
+import Foundation
+
+struct Batch: Codable {
+    var id: Int
+    var iteration: String
+    var uuid: String
+    var displayName: String
+}

--- a/Learn/models/Course.swift
+++ b/Learn/models/Course.swift
@@ -1,0 +1,16 @@
+//
+//  Course.swift
+//  Learn
+//
+//  Created by Luke Ghenco on 4/2/19.
+//  Copyright © 2019 Johann Kerr. All rights reserved.
+//
+
+import Foundation
+
+struct Course: Codable {
+    var id: Int
+    var displayName: String
+    var slug: String
+    var uuid: String
+}

--- a/Learn/models/Track.swift
+++ b/Learn/models/Track.swift
@@ -1,0 +1,15 @@
+//
+//  Track.swift
+//  Learn
+//
+//  Created by Luke Ghenco on 4/2/19.
+//  Copyright © 2019 Johann Kerr. All rights reserved.
+//
+
+import Foundation
+
+struct Track: Codable {
+    var id: Int
+    var title: String
+    var slug: String
+}

--- a/Learn/models/User.swift
+++ b/Learn/models/User.swift
@@ -17,16 +17,16 @@ struct StudentDataTransformer : Codable {
 
 struct Student: Codable {
     var id: Int
-    var fullName: String
-    var email: String
-    var githubGravatar: String?
-    var githubUsername: String?
+    var learnUuid: String
+    var displayName: String
     var lastSeenAt: String?
+    var learnUsername: String
+    var gravatarUrl: String?
     var velocity: Int
     var completedLessonsCount: Int
     var totalLessonsCount: Int
-    var completedLabsCount: Int
-    var totalLabsCount: Int
-    var batchId: String
-    var trackId: String
+    var email: String
+    var activeBatch: Batch
+    var activeTrack: Track
+    var activeCourse: Course
 }

--- a/Learn/stores/UserDataStore.swift
+++ b/Learn/stores/UserDataStore.swift
@@ -15,6 +15,13 @@ final class UserDataStore {
     
     fileprivate init() {}
     
+    func fetchProfile(completion: @escaping (Student) -> ()) {
+        LearnApi.getProfile() { (student) in
+            self.student = student
+            completion(student)
+        }
+    }
+    
     
     func fetchProgress(completion: @escaping (Student) -> ()) {
         LearnApi.getCanonicalProgress(batch: "597", track: "25054") { (student) in

--- a/Learn/utilities/Constants.swift
+++ b/Learn/utilities/Constants.swift
@@ -14,5 +14,6 @@ struct Constants {
     static let batch = "397"
     static let track = "4443"
     static let id = 17263
+    static let learnAPI = "https://qa-ironboard04.fe.flatironschool.com"
 }
 

--- a/Learn/utilities/Constants.swift
+++ b/Learn/utilities/Constants.swift
@@ -14,6 +14,7 @@ struct Constants {
     static let batch = "397"
     static let track = "4443"
     static let id = 17263
-    static let learnAPI = "https://qa-ironboard04.fe.flatironschool.com"
+    static let qaLearnAPI = "https://qa-ironboard04.fe.flatironschool.com"
+    static let localLearnAPI = "https://ea166a80.ngrok.io"
 }
 

--- a/Learn/utilities/Switcher.swift
+++ b/Learn/utilities/Switcher.swift
@@ -13,7 +13,7 @@ class Switcher {
 
     static func updateVC() {
         var rootVC: UIViewController!
-        if loggedIn() {
+        if isLoggedIn() {
             rootVC = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "homeVC")
         } else {
              rootVC = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "loginVC")
@@ -22,8 +22,8 @@ class Switcher {
         appDelegate.window?.rootViewController = rootVC
     }
     
-    static func loggedIn() -> Bool {
-        guard let token =  UserDefaults.standard.string(forKey: "token") else { return false }
+    static func isLoggedIn() -> Bool {
+        guard UserDefaults.standard.string(forKey: "token") != nil else { return false }
         return true
     }
 }


### PR DESCRIPTION
# Description 

Successfully renders dynamic profile info for a user (i.e. Gravatar, Learn Display Name, Lesson Completion/Total Lesson Count & Velocity). All of the info is being loaded now through an endpoint created @ https://github.com/flatiron-labs/ironboard/compare/profiles-api?expand=1 

## Other changes

- Adds additional data models for Batch, Track and Course that is now being sent from the /api/profiles/:identifier API through the LearnApi.fetchProfile function.
- Added a qaLearnUrl and a localLearnUrl to the Constants file that we can manually change on our local machines (need to learn how to make this dynamic to each of our computers, but did this for now)